### PR TITLE
Add assertions to document critical assumptions in code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,9 @@ plugins {
     id 'java'
     id 'application'
     id 'checkstyle'
+    id 'org.openjfx.javafxplugin' version '0.0.10'
     id 'com.github.johnrengelman.shadow' version '7.1.2'
+
 }
 
 checkstyle {

--- a/src/main/java/kleebot/KleeBot.java
+++ b/src/main/java/kleebot/KleeBot.java
@@ -20,6 +20,7 @@ public class KleeBot {
     private Parser parser;
 
     public KleeBot(String filePath) {
+        assert filePath != null : "File path should not be null";
         ui = new Ui();
         storage = new Storage(filePath);
         try {
@@ -62,6 +63,7 @@ public class KleeBot {
         try {
             Command c = Parser.parse(response);
             String kleeText = c.executeGUI(tasks, ui, storage);
+            assert !kleeText.isEmpty();
             return kleeText;
         } catch (KleeExceptions e) {
             return e.getMessage();

--- a/src/main/java/kleebot/Main.java
+++ b/src/main/java/kleebot/Main.java
@@ -49,6 +49,7 @@ public class Main extends Application {
             stage.setScene(scene);
             stage.setMinHeight(220);
             stage.setMinWidth(417);
+
             fxmlLoader.<MainWindow>getController().setKlee(kleeBot);  // inject the Duke instance
             stage.show();
         } catch (IOException e) {

--- a/src/main/java/kleebot/controller/MainWindow.java
+++ b/src/main/java/kleebot/controller/MainWindow.java
@@ -51,6 +51,8 @@ public class MainWindow {
         String userText = userInput.getText();
         String kleeText = kleeBot.getResponse(userText);
 
+        assert !kleeText.isEmpty();
+
         dialogContainer.getChildren().addAll(
                 DialogBox.getUserDialog(userText, userImage),
                 DialogBox.getKleeDialog(kleeText, kleeImage)

--- a/src/main/java/kleebot/storage/Storage.java
+++ b/src/main/java/kleebot/storage/Storage.java
@@ -48,6 +48,7 @@ public class Storage {
                         tasks.add(tmpE);
                         break;
                     default:
+                        assert false : "Unknown task type found in storage: " + type;
                         break;
                     }
                 }
@@ -56,7 +57,8 @@ public class Storage {
             }
         } else { // file doesnt exist yet
             try {
-                boolean _s = file.createNewFile();
+                boolean _success = file.createNewFile();
+                assert _success : "Failed to create new file at: " + filePath;
                 System.out.println("File created" + file.getName());
             } catch (IOException e) {
                 System.out.println("Something went wrong with creating a new file!! >_< I'm so sowwy :((");

--- a/src/main/java/kleebot/ui/Parser.java
+++ b/src/main/java/kleebot/ui/Parser.java
@@ -17,6 +17,8 @@ public class Parser {
     public static Command parse(String fullCommand) throws KleeExceptions {
         String[] parts = fullCommand.split("\\s+");
         String taskDescription;
+        assert parts.length > 0 : "Command parts should not be empty";
+
         switch (parts[0]) {
         case "bye":
             return new ExitCommand();
@@ -94,6 +96,7 @@ public class Parser {
 
 
     public static String parseDateStr(String str) {
+        assert str != null : "Date string cannot be null";
         DateTimeFormatter formatter = new DateTimeFormatterBuilder()
                 .append(DateTimeFormatter.ofPattern("[MM/dd/yyyy]" + "[yyyy/MM/dd]" + "[dd-MM-yyyy]" + "[yyyy-MM-dd]"))
                 .toFormatter();


### PR DESCRIPTION
Some assumptions in the code are implicit and not enforced, which can lead to bugs or unintended behavior if the assumptions are ever violated.

Let's use Java's `assert` feature to document and verify these assumptions at runtime during development.

This change improves code robustness by ensuring these expectations are explicitly stated and validated. It also serves as developer documentation for future maintainers.

Note: Assertions are disabled by default at runtime and must be enabled manually, either with the -ea flag or via build.gradle modification.